### PR TITLE
Removed -f option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,3 @@ EXPOSE 9300
 
 # Define an entry point.
 ENTRYPOINT ["/usr/share/elasticsearch/bin/elasticsearch"]
-CMD ["-f"]


### PR DESCRIPTION
removed -f flag as it is no longer valid option in ES 1.0 (ref: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_system_and_settings.html)
