### PR TITLE
Store instance data in docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN \
 # Define mountable directories.
 VOLUME ["/data"]
 
+# Mount elasticsearch.yml config
+ADD config/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+
 # Define working directory.
 WORKDIR /data
 

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,0 +1,5 @@
+path:
+  data: /data/data
+  logs: /data/log
+  plugins: /data/plugins
+  work: /data/work


### PR DESCRIPTION
config/elasticsearch.yml to store data, logs, plugins, and work(tmp) dirs in /data
ADD config/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
## 

Currently, `docker run`ing the **dockerfile/elasticsearch** container doesn't store the Elasticsearch instance data on a docker volume (as explained in the README). This can cause unexpected data loss (and lack of data reusability with --volumes-from) for users that fail to configure the container volume (& ES config) per the README.

This change adds a short config that specifies the data, logs, plugins, and "work"(tmp) directories should reside on the docker volume by default.
