### PR TITLE
Switched to entrypoint instead of cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ADD config/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
 WORKDIR /data
 
 # Define default command.
-CMD ["/elasticsearch/bin/elasticsearch"]
+ENTRYPOINT ["/elasticsearch/bin/elasticsearch"]
 
 # Expose ports.
 #   - 9200: HTTP

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository contains **Dockerfile** of [ElasticSearch](http://www.elasticsea
   3. Start a container by mounting data directory and specifying the custom configuration file:
 
     ```sh
-    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data dockerfile/elasticsearch /elasticsearch/bin/elasticsearch -Des.config=/data/elasticsearch.yml
+    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data dockerfile/elasticsearch -Des.config=/data/elasticsearch.yml
     ```
 
 After few seconds, open `http://<host>:9200` to see the result.


### PR DESCRIPTION
When switching from CMD to ENTRYPOINT it will be easy to add command line arguments to elasticsearch without knowing the location of the elasticsearch binary inside the container. Running this container without arguments will stay the same
`docker run -d -p 9200:9200 -p 9300:9300 dockerfile/elasticsearch`

and running with arguments will be 
`docker run -d -p 9200:9200 -p 9300:9300 dockerfile/elasticsearch -Des.network.publish_host=192.168.59.103`
