### PR TITLE
Update to 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Pull base image.
 FROM dockerfile/java:oracle-java7
 
-ENV ES_PKG_NAME elasticsearch-1.4.1
+ENV ES_PKG_NAME elasticsearch-1.4.2
 
 # Install ElasticSearch.
 RUN \


### PR DESCRIPTION
Most current Elasticsearch version is 1.4.2