### PR TITLE
update to v1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Pull base image.
 FROM dockerfile/java:oracle-java8
 
-ENV ES_PKG_NAME elasticsearch-1.4.4
+ENV ES_PKG_NAME elasticsearch-1.5.0
 
 # Install Elasticsearch.
 RUN \


### PR DESCRIPTION
Suggestion, would probably be a good idea to alias the previous tag `:1.4.4` then publish this change as `:1.5.0` and latest.