### PR TITLE
Update Elasticsearch version to 1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Pull base image.
 FROM dockerfile/java:oracle-java8
 
-ENV ES_PKG_NAME elasticsearch-1.5.0
+ENV ES_PKG_NAME elasticsearch-1.5.1
 
 # Install Elasticsearch.
 RUN \


### PR DESCRIPTION
Here's the changelog between v1.5.0 and v1.5.1 : https://www.elastic.co/downloads/past-releases/elasticsearch-1-5-1 
