### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsea
 
 1. Install [Docker](https://www.docker.com/).
 
-2. Download [automated build](https://registry.hub.docker.com/u/dockerfile/elasticsearch/) from public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull dockerfile/elasticsearch`
+2. Download [automated build](https://registry.hub.docker.com/u/dockerfile/elasticsearch/) from public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull elasticsearch`
 
    (alternatively, you can build an image from Dockerfile: `docker build -t="dockerfile/elasticsearch" github.com/dockerfile/elasticsearch`)
 
 
 ### Usage
 
-    docker run -d -p 9200:9200 -p 9300:9300 dockerfile/elasticsearch
+    docker run -d -p 9200:9200 -p 9300:9300 elasticsearch
 
 #### Attach persistent/shared directories
 
@@ -37,7 +37,7 @@ This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsea
   3. Start a container by mounting data directory and specifying the custom configuration file:
 
     ```sh
-    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data dockerfile/elasticsearch /elasticsearch/bin/elasticsearch -Des.config=/data/elasticsearch.yml
+    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data elasticsearch /elasticsearch/bin/elasticsearch -Des.config=/data/elasticsearch.yml
     ```
 
 After few seconds, open `http://<host>:9200` to see the result.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsea
 
 #### Attach persistent/shared directories
 
-  1. Create a mountable data directory `<data-dir>` on the host.
+  1. Create a mountable data directory `<data-dir>` on the host and make sure it has proper permissions (chmod 777 <data-dir>).
 
   2. Create Elasticsearch config file at `<data-dir>/elasticsearch.yml`.
 
@@ -37,7 +37,7 @@ This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsea
   3. Start a container by mounting data directory and specifying the custom configuration file:
 
     ```sh
-    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data elasticsearch /elasticsearch/bin/elasticsearch -Des.config=/data/elasticsearch.yml
+    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data elasticsearch elasticsearch -Des.config=/data/elasticsearch.yml
     ```
 
 After few seconds, open `http://<host>:9200` to see the result.


### PR DESCRIPTION
Changing "dockerfile/elasticsearch" to "elasticsearch" to fix "Error: image dockerfile/elasticsearch:latest not found" error.
