### PR TITLE
Update java image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image.
-FROM dockerfile/java:oracle-java8
+FROM java:8
 
 ENV ES_PKG_NAME elasticsearch-1.5.0
 


### PR DESCRIPTION
dockerfile/java:oracle-java8 does not exist anymore (see http://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/ for more info)
