### PR TITLE
Remove dockerfile prefix from README text

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsea
 
 1. Install [Docker](https://www.docker.com/).
 
-2. Download [automated build](https://registry.hub.docker.com/u/dockerfile/elasticsearch/) from public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull dockerfile/elasticsearch`
+2. Download [automated build](https://registry.hub.docker.com/u/dockerfile/elasticsearch/) from public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull elasticsearch`
 
-   (alternatively, you can build an image from Dockerfile: `docker build -t="dockerfile/elasticsearch" github.com/dockerfile/elasticsearch`)
+   (alternatively, you can build an image from Dockerfile: `docker build -t="elasticsearch" github.com/dockerfile/elasticsearch`)
 
 
 ### Usage
@@ -37,7 +37,7 @@ This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsea
   3. Start a container by mounting data directory and specifying the custom configuration file:
 
     ```sh
-    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data dockerfile/elasticsearch /elasticsearch/bin/elasticsearch -Des.config=/data/elasticsearch.yml
+    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data elasticsearch /elasticsearch/bin/elasticsearch -Des.config=/data/elasticsearch.yml
     ```
 
 After few seconds, open `http://<host>:9200` to see the result.


### PR DESCRIPTION
The prefix is no longer required, as part of https://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/
