### PR TITLE
Update to use v2.1.1 and added head plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,28 +5,28 @@
 #
 
 # Pull base image.
-FROM dockerfile/java:oracle-java8
+FROM java:7
 
-ENV ES_PKG_NAME elasticsearch-1.5.0
+ENV ES_PKG_NAME elasticsearch-2.1.1
 
 # Install Elasticsearch.
 RUN \
-  cd / && \
-  wget https://download.elasticsearch.org/elasticsearch/elasticsearch/$ES_PKG_NAME.tar.gz && \
-  tar xvzf $ES_PKG_NAME.tar.gz && \
-  rm -f $ES_PKG_NAME.tar.gz && \
-  mv /$ES_PKG_NAME /elasticsearch
+    cd / && \
+    wget https://download.elasticsearch.org/elasticsearch/elasticsearch/$ES_PKG_NAME.tar.gz && \
+    tar xf $ES_PKG_NAME.tar.gz && \
+    mv $ES_PKG_NAME elasticsearch && \
+    /elasticsearch/bin/plugin install mobz/elasticsearch-head
 
-# Define mountable directories.
 VOLUME ["/data"]
 
 # Mount elasticsearch.yml config
 ADD config/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
 
-# Define working directory.
 WORKDIR /data
 
 # Define default command.
+RUN useradd -ms /bin/bash es
+USER es
 CMD ["/elasticsearch/bin/elasticsearch"]
 
 # Expose ports.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,33 @@
 ## Elasticsearch Dockerfile
 
 
-This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsearch.org/) for [Docker](https://www.docker.com/)'s [automated build](https://registry.hub.docker.com/u/dockerfile/elasticsearch/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
+This repository contains **Dockerfile** of [Elasticsearch v2.1.1](http://www.elasticsearch.org/) for [Docker](https://www.docker.com/) including some helpful plugin(s).
+
+## Plugins included
+- `mobz/elasticsearch-head`
 
 
 ### Base Docker Image
 
-* [dockerfile/java:oracle-java8](http://dockerfile.github.io/#/java)
+* [dockerfile/java:7](http://dockerfile.github.io/#/java)
 
 
 ### Installation
 
 1. Install [Docker](https://www.docker.com/).
 
-2. Download [automated build](https://registry.hub.docker.com/u/dockerfile/elasticsearch/) from public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull dockerfile/elasticsearch`
-
-   (alternatively, you can build an image from Dockerfile: `docker build -t="dockerfile/elasticsearch" github.com/dockerfile/elasticsearch`)
+2. Build image from Dockerfile, from directory containing `Dockerfile`:
+      - `docker build -t "some_image_name" .`
 
 
 ### Usage
 
-    docker run -d -p 9200:9200 -p 9300:9300 dockerfile/elasticsearch
+   ```
+    docker run -d -p 9200:9200 -p 9300:9300 -v "$PWD/data":/data <image_name> /elasticsearch/bin/elasticsearch -Des.network.host=::0
+   ```
 
-#### Attach persistent/shared directories
+Above command will automatically create `data` directory in folder where you run it. If you want to have `data` in some other directory, change the part `$PWD/data` to desired path.
 
-  1. Create a mountable data directory `<data-dir>` on the host.
+After few seconds, open `http://<host>:9200` or run `curl http://<host>:9200/` to verify it is all good. Otherwise, check `<data-dir>/log/elasticsearch.log` file.
 
-  2. Create Elasticsearch config file at `<data-dir>/elasticsearch.yml`.
-
-    ```yml
-    path:
-      logs: /data/log
-      data: /data/data
-    ```
-
-  3. Start a container by mounting data directory and specifying the custom configuration file:
-
-    ```sh
-    docker run -d -p 9200:9200 -p 9300:9300 -v <data-dir>:/data dockerfile/elasticsearch /elasticsearch/bin/elasticsearch -Des.config=/data/elasticsearch.yml
-    ```
-
-After few seconds, open `http://<host>:9200` to see the result.
+HEAD plugin is available on address `http://<host>:9200/_plugin/head`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ This repository contains **Dockerfile** of [Elasticsearch v2.1.1](http://www.ela
 ### Usage
 
 ```sh 
-docker run -d -p 9200:9200 -p 9300:9300 -v "$PWD/data":/data <image_name> /elasticsearch/bin/elasticsearch -Des.network.host=::0
+docker run -d -p 9200:9200 -p 9300:9300 -v "$PWD/data":/data <image_name> \ 
+        /elasticsearch/bin/elasticsearch -Des.network.host=::0
 ```
 
 Above command will automatically create `data` directory in folder where you run it. If you want to have `data` in some other directory, change the part `$PWD/data` to desired path.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ This repository contains **Dockerfile** of [Elasticsearch v2.1.1](http://www.ela
 
 ### Usage
 
-   ```
-    docker run -d -p 9200:9200 -p 9300:9300 -v "$PWD/data":/data <image_name> /elasticsearch/bin/elasticsearch -Des.network.host=::0
-   ```
+```sh 
+docker run -d -p 9200:9200 -p 9300:9300 -v "$PWD/data":/data <image_name> /elasticsearch/bin/elasticsearch -Des.network.host=::0
+```
 
 Above command will automatically create `data` directory in folder where you run it. If you want to have `data` in some other directory, change the part `$PWD/data` to desired path.
 

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,5 +1,7 @@
 path:
   data: /data/data
   logs: /data/log
-  plugins: /data/plugins
   work: /data/work
+  scripts: /data/scripts
+script.inline: on
+script.indexed: on


### PR DESCRIPTION
Hi,

I updated Dockerfile and elasticsearch.yml to install version 2.1.1 of ElasticSearch, including "head" plugin. 

Also updated README because es.config parameter doesn't work on v2 anymore and elasticsearch itself needs to be run a bit differently (specifying host directive)

Cheers
Marin
