### PR TITLE
simple fix to the update java docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image.
-FROM dockerfile/java:oracle-java8
+FROM java:8
 
 ENV ES_PKG_NAME elasticsearch-1.5.0
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains **Dockerfile** of [Elasticsearch](http://www.elasticsea
 
 ### Base Docker Image
 
-* [dockerfile/java:oracle-java8](http://dockerfile.github.io/#/java)
+* [java:8](https://hub.docker.com/_/java/)
 
 
 ### Installation


### PR DESCRIPTION
Since the repo for docker java image is changed, Dockerfile does't work with older repo.

https://github.com/dockerfile/java/issues/19, (though java docker image seems to be deprecated in favour of openjdk after 2016. )

Fixes -https://github.com/dockerfile/elasticsearch/issues/61

cc @pilwon 
